### PR TITLE
Misc. chores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ tasks.json
 ## ignore whole .idea
 .idea/*
 alarm.iml
+
+.rustc_info.json

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,4 @@
 max_width = 80
-reorder_imported_names = true
-reorder_imports = true
-reorder_imports_in_group = true
 match_block_trailing_comma = true
 wrap_comments = true
 use_try_shorthand = true


### PR DESCRIPTION
Fix rustfmt options that have been removed, add `.rustc_info.json` to gitignore.